### PR TITLE
Migrate scripts to @neon/sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@neondatabase/api-client": "^1.10.3",
+        "@neon/sdk": "^1.1.0",
         "@neondatabase/serverless": "^0.10.3",
         "commander": "^12.1.0",
         "dotenv": "^16.4.5",
@@ -804,13 +804,13 @@
         "node": ">=12"
       }
     },
-    "node_modules/@neondatabase/api-client": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@neondatabase/api-client/-/api-client-1.10.3.tgz",
-      "integrity": "sha512-rqCtsR8OYATD6bCdv4Qj/zYNAEHYZ93sYktWIDl1kdXSzrxt+SkHDNrp4zQFsnnfjiLg527l6oRJ8rd8H72ZiA==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.6.0"
+    "node_modules/@neon/sdk": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@neon/sdk/-/sdk-1.1.0.tgz",
+      "integrity": "sha512-MMjKmT1lmfj3wKcZyqXMDg0hdgcmT50RAcbSpKuDLvT80sl3Xd2DDc77vemfA61pqJG/QcKO96R0E0MOX5j8Ww==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@neondatabase/serverless": {
@@ -1188,23 +1188,6 @@
         "pg-types": "^4.0.1"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/before-after-hook": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
@@ -1222,18 +1205,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/commander": {
       "version": "12.1.0",
@@ -1259,15 +1230,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/dotenv": {
@@ -1472,40 +1434,6 @@
         "esbuild": ">=0.12 <1"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/get-tsconfig": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
@@ -1541,27 +1469,6 @@
       "license": "ISC",
       "engines": {
         "node": "18 >=18.20 || 20 || >=22"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/ms": {
@@ -1682,12 +1589,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
       "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
-      "license": "MIT"
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@neondatabase/api-client": "^1.10.3",
+    "@neon/sdk": "^1.1.0",
     "@neondatabase/serverless": "^0.10.3",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",

--- a/src/scripts/create.js
+++ b/src/scripts/create.js
@@ -1,10 +1,11 @@
 import { Command } from 'commander';
-import { createApiClient } from '@neondatabase/api-client';
+import { createNeonClient } from '@neon/sdk';
 import 'dotenv/config';
 
 const program = new Command();
-const neonApi = createApiClient({
+const neonApi = createNeonClient({
   apiKey: process.env.NEON_API_KEY,
+  throwOnError: true,
 });
 
 program.option('-n, --name <name>', 'name of the company').parse(process.argv);
@@ -15,17 +16,14 @@ if (options.name) {
   console.log(`Company Name: ${options.name}`);
   console.log(typeof options.name);
 
-  const response = await neonApi.createProject({
-    project: {
-      name: options.name,
-      pg_version: 16,
-      region_id: 'aws-us-east-1',
-      // org_id: '',
-    },
+  const project = await neonApi.projects.create({
+    name: options.name,
+    pg_version: 16,
+    region_id: 'aws-us-east-1',
+    // org_id: '',
   });
 
-  const { data } = await response;
-  console.log(data);
+  console.log(project);
 } else {
   console.log('No company name provided');
 }

--- a/src/scripts/generate.js
+++ b/src/scripts/generate.js
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { execSync } from 'child_process';
-import { createApiClient } from '@neondatabase/api-client';
+import { createNeonClient } from '@neon/sdk';
 import { Octokit } from 'octokit';
 import 'dotenv/config';
 
@@ -9,8 +9,9 @@ import { drizzleConfig } from '../templates/drizzle-config.js';
 import { githubWorkflow } from '../templates/github-workflow.js';
 
 const octokit = new Octokit({ auth: process.env.PERSONAL_ACCESS_TOKEN });
-const neonApi = createApiClient({
+const neonApi = createNeonClient({
   apiKey: process.env.NEON_API_KEY,
+  throwOnError: true,
 });
 
 const repoOwner = 'PaulieScanlon';
@@ -31,25 +32,17 @@ let secrets = [];
     }
   );
 
-  const response = await neonApi.listProjects();
-
-  const {
-    data: { projects },
-  } = await response;
+  const projects = await neonApi.projects.list().all();
 
   await Promise.all(
     projects.map(async (project) => {
       const { id, name } = project;
 
-      const response = await neonApi.getConnectionUri({
+      const uri = await neonApi.postgres.connectionString({
         projectId: id,
-        database_name: 'neondb',
-        role_name: 'neondb_owner',
+        databaseName: 'neondb',
+        roleName: 'neondb_owner',
       });
-
-      const {
-        data: { uri },
-      } = await response;
 
       const safeName = name.replace(/\s+/g, '-').toLowerCase();
       const path = `configs/${safeName}`;


### PR DESCRIPTION
## Summary
- Replace the legacy `@neondatabase/api-client` dependency with `@neon/sdk`.
- Update project creation and connection string generation scripts to use `createNeonClient` management APIs.

## Test plan
- `node --check src/scripts/create.js && node --check src/scripts/generate.js`
- `npm run create` (no-op path, without `--name`)
- `node -e \"import('@neon/sdk').then(({createNeonClient}) => { const neon = createNeonClient({ apiKey: 'test', throwOnError: true }); if (!neon.projects || !neon.postgres) throw new Error('missing namespaces'); console.log('sdk import ok'); })\"`

Note: live Neon provisioning was not run because `NEON_API_KEY` is not available in this shell.